### PR TITLE
Compatibility with Java 1.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'adopt'
           server-id: forgerock-private-releases
           server-username: FORGEROCK_MVN_USER

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '8'
           distribution: 'adopt'
           server-id: forgerock-private-releases
           server-username: FORGEROCK_MVN_USER

--- a/pom.xml
+++ b/pom.xml
@@ -126,18 +126,26 @@
   <repositories>
     <repository>
       <id>forgerock-private-releases</id>
-      <url>https://maven.forgerock.org/repo/private-releases</url>
+      <url>https://maven.forgerock.org:443/repo/private-releases</url>
+      <releases>
+        <enabled>true</enabled>
+        <checksumPolicy>fail</checksumPolicy>
+      </releases>
       <snapshots>
         <enabled>false</enabled>
+        <checksumPolicy>warn</checksumPolicy>
       </snapshots>
     </repository>
     <repository>
-      <id>oracleReleases</id>
-      <name>Oracle Released Java Packages</name>
-      <url>https://maven.oracle.com</url>
-      <layout>default</layout>
-      <snapshots>
+      <id>forgerock-private-snapshots</id>
+      <url>https://maven.forgerock.org:443/repo/private-snapshots</url>
+      <releases>
         <enabled>false</enabled>
+        <checksumPolicy>fail</checksumPolicy>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+        <checksumPolicy>warn</checksumPolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>edu.northwestern.admin-systems</groupId>
   <artifactId>duo-universal-prompt-auth-node</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.3</version>
+  <version>1.0.4</version>
 
   <name>Duo Universal Prompt Auth Tree Node</name>
   <description>An Authentication Tree Node for ForgeRock's Identity Platform which integrates Duo's v4 web SDK,
@@ -35,9 +35,9 @@
   </scm>
 
   <properties>
-    <am.version>7.0.0</am.version>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <am.version>6.5.3</am.version>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,26 +126,18 @@
   <repositories>
     <repository>
       <id>forgerock-private-releases</id>
-      <url>https://maven.forgerock.org:443/repo/private-releases</url>
-      <releases>
-        <enabled>true</enabled>
-        <checksumPolicy>fail</checksumPolicy>
-      </releases>
+      <url>https://maven.forgerock.org/repo/private-releases</url>
       <snapshots>
         <enabled>false</enabled>
-        <checksumPolicy>warn</checksumPolicy>
       </snapshots>
     </repository>
     <repository>
-      <id>forgerock-private-snapshots</id>
-      <url>https://maven.forgerock.org:443/repo/private-snapshots</url>
-      <releases>
-        <enabled>false</enabled>
-        <checksumPolicy>fail</checksumPolicy>
-      </releases>
+      <id>oracle-repository</id>
+      <name>Oracle</name>
+      <url>https://download.oracle.com/maven</url>
+      <layout>default</layout>
       <snapshots>
-        <enabled>true</enabled>
-        <checksumPolicy>warn</checksumPolicy>
+        <enabled>false</enabled>
       </snapshots>
     </repository>
   </repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -131,5 +131,14 @@
         <enabled>false</enabled>
       </snapshots>
     </repository>
+    <repository>
+      <id>oracleReleases</id>
+      <name>Oracle Released Java Packages</name>
+      <url>https://maven.oracle.com</url>
+      <layout>default</layout>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
   </repositories>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -132,6 +132,7 @@
       </snapshots>
     </repository>
     <repository>
+      <!-- com.sleepycat.je isn't being pulled from ForgeRock's repo, but Oracle has it. -->
       <id>oracle-repository</id>
       <name>Oracle</name>
       <url>https://download.oracle.com/maven</url>


### PR DESCRIPTION
Swapping to Java 1.8 meant I needed to build against the OpenAM 6.5.3 (instead of 7) libs, since some of those are built for Java 11 and the compiler won't let me do that.

There was a weird issue w/ the deps for 6.5.3. I thought ForgeRock was supposed to mirror all of them, but one random package was missing from their repo. I added Oracle's repo to the pom and it can find it there.