### PR TITLE
Duo bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v1.0.1] - 2021-07-27
+### Changes
+- Bumped Duo SDK to v1.1.2.
+
+## [v1.0.0] - 2021-05-26
+### Added
+Initial release.

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
   <groupId>edu.northwestern.admin-systems</groupId>
   <artifactId>duo-universal-prompt-auth-node</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
 
   <name>Duo Universal Prompt Auth Tree Node</name>
   <description>An Authentication Tree Node for ForgeRock's Identity Platform which integrates Duo's v4 web SDK,
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>com.duosecurity</groupId>
       <artifactId>duo-universal-sdk</artifactId>
-      <version>1.1.1</version>
+      <version>1.1.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Bumps the [Duo SDK to the latest version](https://github.com/duosecurity/duo_universal_java/releases/tag/1.1.2). It's just fixing the NPE when we get an error back.

In theory, their improved error handling will allow OpenAM to handle the node's failure more gracefully. I'm not sure how important that is in practice -- that API doesn't have any business failing.

Also: once this is merged and tagged, I'm going to set the repo to public so the rest of the world can enjoy it.