### PR TITLE
RELENG-2330 Replace the legacy /repo prefix in the Artifactory URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The OpenAM callback URL is where Duo should redirect users to after they have fi
 ## Development
 You will need a ForgeRock Backstage account attached to an OpenAM subscription in order to download the dependencies. [Create an account](https://backstage.forgerock.com/) & then contact your OpenAM administrators for help with that.
 
-Once you are part of a subscription, visit [their article on accessing their private Maven repositories](https://backstage.forgerock.com/knowledge/kb/article/a74096897) for instructions on configuring your Maven install with credentials. Notably, [their generated ~/.m2/settings.xml](https://maven.forgerock.org/repo/private-releases/settings.xml) must be downloaded & put in place.
+Once you are part of a subscription, visit [their article on accessing their private Maven repositories](https://backstage.forgerock.com/knowledge/kb/article/a74096897) for instructions on configuring your Maven install with credentials. Notably, [their generated ~/.m2/settings.xml](https://maven.forgerock.org/artifactory/private-releases/settings.xml) must be downloaded & put in place.
 
 From there, you can load the project up. Maven will retrieve all necessary dependencies.
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
   <repositories>
     <repository>
       <id>forgerock-private-releases</id>
-      <url>https://maven.forgerock.org/repo/private-releases</url>
+      <url>https://maven.forgerock.org/artifactory/private-releases</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
Hi,
The ForgeRock Artifactory instance will soon move to the JFrog.io SaaS.
The URL will remain the same but the /repo prefix won't work anymore.
Thanks,
Bruno Lavit, release manager at ForgeRock